### PR TITLE
feat: 피드(Home) 컴포넌트 구현

### DIFF
--- a/src/components/post/PostAuthor/PostAuthor.jsx
+++ b/src/components/post/PostAuthor/PostAuthor.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import DefaultProfileImg from './../../../assets/basic-profile-img-.svg';
 import * as S from './PostAuthor.style';
 
-const PostAuthor = () => {
+const PostAuthor = (data) => {
   return (
     <S.AuthorWrap>
-      <S.ProfileImgWrap src={DefaultProfileImg}></S.ProfileImgWrap>
+      <S.ProfileImgWrap src={data && data.data.image}></S.ProfileImgWrap>
       <S.AuthorInfo>
-        <S.AuthorName>애월읍 위니브 감귤농장</S.AuthorName>
-        <S.AuthorId>@ weniv_Mandarin</S.AuthorId>
+        <S.AuthorName>{data && data.data.username}</S.AuthorName>
+        <S.AuthorId>@ {data && data.data.accountname}</S.AuthorId>
       </S.AuthorInfo>
     </S.AuthorWrap>
   );

--- a/src/components/post/PostAuthor/PostAuthor.jsx
+++ b/src/components/post/PostAuthor/PostAuthor.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import DefaultProfileImg from './../../../assets/basic-profile-img-.svg';
+import * as S from './PostAuthor.style';
+
+const PostAuthor = () => {
+  return (
+    <S.AuthorWrap>
+      <S.ProfileImgWrap src={DefaultProfileImg}></S.ProfileImgWrap>
+      <S.AuthorInfo>
+        <S.AuthorName>애월읍 위니브 감귤농장</S.AuthorName>
+        <S.AuthorId>@ weniv_Mandarin</S.AuthorId>
+      </S.AuthorInfo>
+    </S.AuthorWrap>
+  );
+};
+
+export default PostAuthor;

--- a/src/components/post/PostAuthor/PostAuthor.style.jsx
+++ b/src/components/post/PostAuthor/PostAuthor.style.jsx
@@ -22,14 +22,14 @@ export const ProfileImgWrap = styled.img`
 
 export const AuthorName = styled.article`
   font-weight: 500;
-  font-size: 14px;
-  line-height: 16.71px;
+  font-size: 1.4rem;
+  line-height: 1.671rem;
   margin-bottom: 2px;
 `;
 
 export const AuthorId = styled.article`
   font-weight: 900;
-  font-size: 12px;
-  line-height: 14px;
+  font-size: 1.2rem;
+  line-height: 1.4rem;
   color: ${(props) => props.theme.palette['mediumGray']};
 `;

--- a/src/components/post/PostAuthor/PostAuthor.style.jsx
+++ b/src/components/post/PostAuthor/PostAuthor.style.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const AuthorWrap = styled.section`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  cursor: pointer;
+`;
+
+export const AuthorInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ProfileImgWrap = styled.img`
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  margin-right: 12px;
+`;
+
+export const AuthorName = styled.article`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 16.71px;
+  margin-bottom: 2px;
+`;
+
+export const AuthorId = styled.article`
+  font-weight: 900;
+  font-size: 12px;
+  line-height: 14px;
+  color: ${(props) => props.theme.palette['mediumGray']};
+`;

--- a/src/components/post/PostCard/PostCard.jsx
+++ b/src/components/post/PostCard/PostCard.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import * as S from './PostCard.style';
+import PostContent from '../PostContent/PostContent';
+import PostAuthor from './../PostAuthor/PostAuthor';
+
+const PostCard = () => {
+  return (
+    <S.ProfileWrap>
+      <PostAuthor />
+      <PostContent />
+    </S.ProfileWrap>
+  );
+};
+
+export default PostCard;

--- a/src/components/post/PostCard/PostCard.jsx
+++ b/src/components/post/PostCard/PostCard.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './PostCard.style';
 import PostContent from '../PostContent/PostContent';
 import PostAuthor from './../PostAuthor/PostAuthor';
 
-const PostCard = () => {
+const PostCard = (data) => {
+  const [authorData, setAuthorData] = useState();
+  const [postData, setPostData] = useState();
+
+  useEffect(() => {
+    setAuthorData(data.data.author);
+    setPostData(data.data);
+  }, [data]);
+
   return (
     <S.ProfileWrap>
-      <PostAuthor />
-      <PostContent />
+      {authorData && <PostAuthor data={authorData} />}
+      {postData && <PostContent data={postData} />}
     </S.ProfileWrap>
   );
 };

--- a/src/components/post/PostCard/PostCard.style.jsx
+++ b/src/components/post/PostCard/PostCard.style.jsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const ProfileWrap = styled.article`
+  margin-bottom: 20px;
+  position: relative;
+  max-width: 358px;
+  width: 100%;
+`;

--- a/src/components/post/PostContent/PostContent.jsx
+++ b/src/components/post/PostContent/PostContent.jsx
@@ -34,13 +34,13 @@ const PostContent = () => {
         <S.PostIconBtn onClick={handleLike}>
           <HeartIcon
             fill={isLiked ? '#05704A' : '#fff'}
-            style={{ 'margin-right': '6px' }}
+            style={{ marginRight: '6px' }}
           />
           <span>{heartCount}</span>
         </S.PostIconBtn>
         <a>
           <S.PostIconBtn onClick={handleComment}>
-            <img src={CommentIcon} alt="" style={{ 'margin-right': '6px' }} />
+            <img src={CommentIcon} alt="" style={{ marginRight: '6px' }} />
             <span>{commentCount}</span>
           </S.PostIconBtn>
         </a>

--- a/src/components/post/PostContent/PostContent.jsx
+++ b/src/components/post/PostContent/PostContent.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { ReactComponent as HeartIcon } from './../../../assets/icon-heart.svg';
+import CommentIcon from './../../../assets/icon-message-circle.svg';
+import * as S from './PostContent.style';
+
+const PostContent = () => {
+  const [isLiked, setIsLiked] = useState(false);
+  const [heartCount, setHeartCount] = useState(0);
+  const [commentCount, setCommentCount] = useState(0);
+
+  const handleLike = () => {
+    setIsLiked(!isLiked);
+    setHeartCount(heartCount + 1);
+  };
+
+  const handleComment = () => {
+    setCommentCount(commentCount + 1);
+  };
+
+  return (
+    <S.PostContent>
+      <S.PostTxt>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit.
+      </S.PostTxt>
+      <ul className="ImgList">
+        <li>
+          <S.PostImg
+            src="https://thumbs.gfycat.com/VacantUnpleasantArchaeocete-size_restricted.gif"
+            alt=""
+          />
+        </li>
+      </ul>
+      <S.PostIconsWrap>
+        <S.PostIconBtn onClick={handleLike}>
+          <HeartIcon
+            fill={isLiked ? '#05704A' : '#fff'}
+            style={{ 'margin-right': '6px' }}
+          />
+          <span>{heartCount}</span>
+        </S.PostIconBtn>
+        <a>
+          <S.PostIconBtn onClick={handleComment}>
+            <img src={CommentIcon} alt="" style={{ 'margin-right': '6px' }} />
+            <span>{commentCount}</span>
+          </S.PostIconBtn>
+        </a>
+      </S.PostIconsWrap>
+      <S.PostCreateDate>2022년 07월 11일</S.PostCreateDate>
+    </S.PostContent>
+  );
+};
+
+export default PostContent;

--- a/src/components/post/PostContent/PostContent.jsx
+++ b/src/components/post/PostContent/PostContent.jsx
@@ -3,31 +3,30 @@ import { ReactComponent as HeartIcon } from './../../../assets/icon-heart.svg';
 import CommentIcon from './../../../assets/icon-message-circle.svg';
 import * as S from './PostContent.style';
 
-const PostContent = () => {
-  const [isLiked, setIsLiked] = useState(false);
-  const [heartCount, setHeartCount] = useState(0);
-  const [commentCount, setCommentCount] = useState(0);
+const PostContent = (data) => {
+  const [isLiked, setIsLiked] = useState(null);
 
   const handleLike = () => {
-    setIsLiked(!isLiked);
-    setHeartCount(heartCount + 1);
-  };
-
-  const handleComment = () => {
-    setCommentCount(commentCount + 1);
+    if (!isLiked) {
+      setIsLiked(true);
+      data.data.heartCount++;
+    } else {
+      setIsLiked(false);
+      data.data.heartCount--;
+    }
   };
 
   return (
     <S.PostContent>
-      <S.PostTxt>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit.
-      </S.PostTxt>
+      {console.log(data)}
+      {data.data.content.length === 0 ? null : (
+        <S.PostTxt>{data.data.content}</S.PostTxt>
+      )}
       <ul className="ImgList">
         <li>
-          <S.PostImg
-            src="https://thumbs.gfycat.com/VacantUnpleasantArchaeocete-size_restricted.gif"
-            alt=""
-          />
+          {data.data.image.length === 0 ? null : (
+            <S.PostImg src={data.data.image} alt="" />
+          )}
         </li>
       </ul>
       <S.PostIconsWrap>
@@ -36,12 +35,12 @@ const PostContent = () => {
             fill={isLiked ? '#05704A' : '#fff'}
             style={{ marginRight: '6px' }}
           />
-          <span>{heartCount}</span>
+          <span>{data.data.heartCount}</span>
         </S.PostIconBtn>
         <a>
-          <S.PostIconBtn onClick={handleComment}>
+          <S.PostIconBtn>
             <img src={CommentIcon} alt="" style={{ marginRight: '6px' }} />
-            <span>{commentCount}</span>
+            <span>{data.data.comments.length}</span>
           </S.PostIconBtn>
         </a>
       </S.PostIconsWrap>

--- a/src/components/post/PostContent/PostContent.style.jsx
+++ b/src/components/post/PostContent/PostContent.style.jsx
@@ -6,8 +6,8 @@ export const PostContent = styled.section`
 
 export const PostTxt = styled.p`
   font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
+  font-size: 1.4rem;
+  line-height: 1.8rem;
   margin-bottom: 16px;
   word-break: break-all;
 `;
@@ -25,8 +25,8 @@ export const PostImg = styled.img`
 export const PostIconsWrap = styled.div`
   display: flex;
   font-weight: 400;
-  font-size: 12px;
-  line-height: 12px;
+  font-size: 1.2rem;
+  line-height: 1.2rem;
   margin-bottom: 16px;
   align-items: center;
 `;

--- a/src/components/post/PostContent/PostContent.style.jsx
+++ b/src/components/post/PostContent/PostContent.style.jsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const PostContent = styled.section`
+  padding-left: 54px;
+`;
+
+export const PostTxt = styled.p`
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  margin-bottom: 16px;
+  word-break: break-all;
+`;
+
+export const ImgList = styled.ul`
+  display: flex;
+  transition: all 0.4s;
+`;
+
+export const PostImg = styled.img`
+  border-radius: 10px;
+  margin-bottom: 16px;
+`;
+
+export const PostIconsWrap = styled.div`
+  display: flex;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 12px;
+  margin-bottom: 16px;
+  align-items: center;
+`;
+
+export const PostIconBtn = styled.button`
+  display: flex;
+  align-items: center;
+  margin-right: 16px;
+`;
+
+export const PostCreateDate = styled.small`
+  font-size: 1rem;
+  line-height: 1.2rem;
+  font-weight: 400;
+  color: ${(props) => props.theme.palette['mediumGray']};
+`;

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import PostCard from '../../components/post/PostCard/PostCard';
+import * as S from './Home.style';
+import { ReactComponent as Logo } from './../../assets/symbol-logo-feed.svg';
+
+const Home = () => {
+  useEffect(() => {}, []);
+  const posts = ['포스트있음'];
+  return (
+    <>
+      {posts.length > 0 ? (
+        <S.PostWrap>
+          <PostCard />
+        </S.PostWrap>
+      ) : (
+        <S.FeedEmptyWrap>
+          <Logo />
+          <S.FeedEmptyTxt>유저를 검색해 팔로우 해보세요!</S.FeedEmptyTxt>
+          <S.Button>검색하기</S.Button>
+        </S.FeedEmptyWrap>
+      )}
+    </>
+  );
+};
+
+export default Home;

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -45,7 +45,6 @@ const Home = () => {
 
   return (
     <>
-      {console.log(userFeedData)}
       {userFeedData && userFeedData.length > 0 ? (
         <>
           <BasicHeader />
@@ -64,7 +63,9 @@ const Home = () => {
             >
               피드나가기
             </button>
-            <PostCard />
+            {userFeedData.map((post) => {
+              return <PostCard key={post.id} data={post} />;
+            })}
           </S.PostWrap>
         </>
       ) : (

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -3,64 +3,70 @@ import React, { useEffect, useState } from 'react';
 import PostCard from '../../components/post/PostCard/PostCard';
 import * as S from './Home.style';
 import { ReactComponent as Logo } from './../../assets/symbol-logo-feed.svg';
+import BasicHeader from '../../components/header/BasicHeader/BasicHeader';
 
 const Home = () => {
   const [logInData, setlogInData] = useState();
-  const [userFeedData, setuserFeedData] = useState();
+  const [userFeedData, setUserFeedData] = useState();
+
+  // get user token when component first mounted
   useEffect(() => {
-    // get user token
     const config = {
       headers: {
         'Content-Type': 'application/json',
       },
     };
     const data = JSON.stringify({
-      user: { email: 'test40@test.com', password: '123123' },
+      user: { email: 'sisikhere@gmail.com', password: '123456' },
     });
     axios
-      .post('https://mandarin.api.weniv.co.kr/user/login', data, config)
+      .post('http://146.56.183.55:5050/user/login', data, config)
       .then((response) => {
         setlogInData(response.data.user);
       })
       .catch((error) => console.log(error));
   }, []);
 
-  useEffect(() => {
-    // get feed data
+  // get feed data
+  const getFeedData = () => {
     if (logInData) {
       axios({
         method: 'get',
-        url: 'https://mandarin.api.weniv.co.kr/post/feed',
+        url: 'http://146.56.183.55:5050/post/feed',
         headers: {
           Authorization: `Bearer ${logInData.token}`,
           'Content-type': 'application/json',
         },
       }).then((response) => {
-        setuserFeedData(response.data);
+        setUserFeedData(response.data.posts);
       });
     }
-  }, [logInData]);
+  };
 
   return (
     <>
-      {userFeedData && userFeedData.posts.length > 0 ? (
-        <S.PostWrap>
-          <button
-            style={{
-              backgroundColor: 'red',
-              color: 'white',
-              padding: '10px',
-              borderRadius: '10px',
-              marginBottom: '20px',
-            }}
-            onClick={() => {
-              setuserFeedData({ posts: [] });
-            }}
-          >
-            피드나가기
-          </button>
-          <PostCard />
-        </S.PostWrap>
+      {console.log(userFeedData)}
+      {userFeedData && userFeedData.length > 0 ? (
+        <>
+          <BasicHeader />
+          <S.PostWrap>
+            <button
+              style={{
+                backgroundColor: 'red',
+                color: 'white',
+                padding: '10px',
+                borderRadius: '10px',
+                marginBottom: '20px',
+              }}
+              onClick={() => {
+                setUserFeedData([]);
+              }}
+            >
+              피드나가기
+            </button>
+            <PostCard />
+          </S.PostWrap>
+        </>
       ) : (
         <S.FeedEmptyWrap>
           <button
@@ -71,9 +77,7 @@ const Home = () => {
               borderRadius: '10px',
               marginBottom: '20px',
             }}
-            onClick={() => {
-              setuserFeedData({ posts: ['아아아악'] });
-            }}
+            onClick={getFeedData}
           >
             피드표시하기
           </button>

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -1,22 +1,87 @@
-import React, { useEffect } from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
 import PostCard from '../../components/post/PostCard/PostCard';
 import * as S from './Home.style';
 import { ReactComponent as Logo } from './../../assets/symbol-logo-feed.svg';
 
 const Home = () => {
-  useEffect(() => {}, []);
-  const posts = ['포스트있음'];
+  const [logInData, setlogInData] = useState();
+  const [userFeedData, setuserFeedData] = useState();
+  useEffect(() => {
+    // get user token
+    const config = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+    const data = JSON.stringify({
+      user: { email: 'test40@test.com', password: '123123' },
+    });
+    axios
+      .post('https://mandarin.api.weniv.co.kr/user/login', data, config)
+      .then((response) => {
+        setlogInData(response.data.user);
+      })
+      .catch((error) => console.log(error));
+  }, []);
+
+  useEffect(() => {
+    // get feed data
+    if (logInData) {
+      axios({
+        method: 'get',
+        url: 'https://mandarin.api.weniv.co.kr/post/feed',
+        headers: {
+          Authorization: `Bearer ${logInData.token}`,
+          'Content-type': 'application/json',
+        },
+      }).then((response) => {
+        setuserFeedData(response.data);
+      });
+    }
+  }, [logInData]);
+
   return (
     <>
-      {posts.length > 0 ? (
+      {userFeedData && userFeedData.posts.length > 0 ? (
         <S.PostWrap>
+          <button
+            style={{
+              backgroundColor: 'red',
+              color: 'white',
+              padding: '10px',
+              borderRadius: '10px',
+              marginBottom: '20px',
+            }}
+            onClick={() => {
+              setuserFeedData({ posts: [] });
+            }}
+          >
+            피드나가기
+          </button>
           <PostCard />
         </S.PostWrap>
       ) : (
         <S.FeedEmptyWrap>
-          <Logo />
-          <S.FeedEmptyTxt>유저를 검색해 팔로우 해보세요!</S.FeedEmptyTxt>
-          <S.Button>검색하기</S.Button>
+          <button
+            style={{
+              backgroundColor: 'red',
+              color: 'white',
+              padding: '10px',
+              borderRadius: '10px',
+              marginBottom: '20px',
+            }}
+            onClick={() => {
+              setuserFeedData({ posts: ['아아아악'] });
+            }}
+          >
+            피드표시하기
+          </button>
+          <div>
+            <Logo />
+            <S.FeedEmptyTxt>유저를 검색해 팔로우 해보세요!</S.FeedEmptyTxt>
+            <S.Button>검색하기</S.Button>
+          </div>
         </S.FeedEmptyWrap>
       )}
     </>

--- a/src/pages/home/Home.style.jsx
+++ b/src/pages/home/Home.style.jsx
@@ -6,7 +6,6 @@ export const PostWrap = styled.main`
   align-items: center;
   padding: 20px 16px 0;
   height: calc(100% - 108px);
-  overflow-y: scroll;
 `;
 
 export const FeedEmptyWrap = styled.div`

--- a/src/pages/home/Home.style.jsx
+++ b/src/pages/home/Home.style.jsx
@@ -10,6 +10,11 @@ export const PostWrap = styled.main`
 `;
 
 export const FeedEmptyWrap = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 10px);
+  flex-direction: column;
   text-align: center;
   background-color: ${(props) => props.theme.palette['primary']};
 `;

--- a/src/pages/home/Home.style.jsx
+++ b/src/pages/home/Home.style.jsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const PostWrap = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px 16px 0;
+  height: calc(100% - 108px);
+  overflow-y: scroll;
+`;
+
+export const FeedEmptyWrap = styled.div`
+  text-align: center;
+  background-color: ${(props) => props.theme.palette['primary']};
+`;
+
+export const FeedEmptyTxt = styled.p`
+  margin-top: 25px;
+  margin-bottom: 20px;
+  color: ${(props) => props.theme.palette['black']};
+  font-size: 1.4rem;
+`;
+
+export const Button = styled.button`
+  color: ${(props) => props.theme.palette['white']};
+  background-color: ${(props) => props.theme.palette['point']};
+  font-size: 1.4rem;
+  border-radius: 44px;
+  width: 120px;
+  height: 44px;
+`;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 피드(Home) 컴포넌트 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- pages 폴더를 생성해 Home을 개별 page로 분리하였습니다.
- PostCard 컴포넌트를 PostContent와 PostAuthor 컴포넌트로 나누었습니다.  
PostContent에는 게시글 내용, PostAuthor는 게시글의 작성자 정보가 표시됩니다.

### 작업 후 기대 동작(스크린샷)

- userFeedData의 length가 > 0인 경우 PostCard 컴포넌트 표시
![image](https://user-images.githubusercontent.com/90305737/178480203-64418ac3-b24f-4844-970e-b9a09150d69f.png)
- userFeedData의 length가 <0인 경우 Empty Feed 화면 표시
![image](https://user-images.githubusercontent.com/90305737/178480278-aa8839b6-8cc9-4f12-8c90-e33a8c21ec46.png)



### PR 특이 사항

- 현재 Home.jsx에서 userFeedData를 받아오고 있는 로직이 다소 조잡합니다. 추후 axios와 데이터공급 로직을 수정/분리할 것을 감안하여 봐주시면 감사하겠습니다.
- api 테스트 차원으로 피드 button을 만들어두었습니다. 데이터 로직 분리 후에 '피드나가기', '피드표시하기' button 삭제 예정입니다.

### Issue Number 

close: #3 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

- page와 컴포넌트 분리가 잘 되었는지, 중복된 코드는 없는지 봐주시면 감사하겠습니다.
- 스타일드 컴포넌트가 적절히 쓰였는지 봐주시면 감사하겠습니다. :)

<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
