### PR TITLE
feat: 검색 페이지 UI 구현

### DIFF
--- a/src/components/search/SearchUserList/SearchUserList.jsx
+++ b/src/components/search/SearchUserList/SearchUserList.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import * as S from './SearchUserList.style.jsx';
+
+const SearchUserList = ({ image, username, accountname }) => {
+  return (
+    <S.SearchUserListWrap>
+      <img src={image} alt="" style={{ width: '30px', height: '30px' }} />
+      <strong>{username}</strong>
+      <strong>{accountname}</strong>
+    </S.SearchUserListWrap>
+  );
+};
+
+export default SearchUserList;

--- a/src/components/search/SearchUserList/SearchUserList.style.jsx
+++ b/src/components/search/SearchUserList/SearchUserList.style.jsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const SearchUserListWrap = styled.div`
+  margin-bottom: 16px;
+`;

--- a/src/pages/Pages.jsx
+++ b/src/pages/Pages.jsx
@@ -3,6 +3,8 @@ import { Routes, Route } from 'react-router-dom';
 import Login from '../components/login/Login';
 import SignIn from '../components/sign-in/SignIn';
 import SerProfile from '../components/sign-in/SetProfile';
+import Home from './home/Home';
+import Search from './search/Search';
 
 function Pages() {
   return (
@@ -10,6 +12,8 @@ function Pages() {
       <Route path="/login" element={<Login />}></Route>
       <Route path="/signin" element={<SignIn />}></Route>
       <Route path="/setProfile" element={<SerProfile />}></Route>
+      <Route path="/home" element={<Home />}></Route>
+      <Route path="/search" element={<Search />}></Route>
     </Routes>
   );
 }

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import SearchHeader from './../../components/header/SearchHeader/SearchHeader';
+import SearchUserList from '../../components/search/SearchUserList/SearchUserList';
+import * as S from './Search.style';
+
+const Search = () => {
+  const [searchData, setSearchData] = useState([]);
+
+  return (
+    <>
+      <SearchHeader />
+      <S.SearchListWrap>
+        {searchData.length === 0 || !searchData
+          ? null
+          : searchData.map((user) => {
+              return (
+                <SearchUserList
+                  key={Math.random() * 100}
+                  image={user.image}
+                  accountname={user.accountname}
+                  username={user.username}
+                />
+              );
+            })}
+      </S.SearchListWrap>
+    </>
+  );
+};
+
+export default Search;

--- a/src/pages/search/Search.style.jsx
+++ b/src/pages/search/Search.style.jsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const SearchListWrap = styled.div`
+  padding: 20px 16px;
+`;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 검색 페이지 UI구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 검색 페이지 header 삽입
- pages.jsx내에 Home과 Search 추가
- pages폴더 내에 Search 추가하여 검색페이지 스타일 설정
- components폴더 내에 SearchUserList 생성하여 검색창 안에 뜰 내용 스타일 설정


### 작업 후 기대 동작(스크린샷)
- searchData.length === 0 이거나 !searchData일 경우, 검색창에 아무것도 렌더되지 않음
![image](https://user-images.githubusercontent.com/90305737/179142281-611324ba-9eb3-4b06-84b4-bc091f959f8e.png)
-  searchData.length !== 0일 경우, Search컴포넌트 내에 SearchUserList가 렌더됨 

### PR 특이 사항

- 추후 SearchUserList 안에 들어가는 내용은 유저컴포넌트로 대체됩니다.
- 추후 하단에 탭 메뉴 컴포넌트 삽입 예정입니다

### Issue Number 

close: #29 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 검색창이 하나의 전체 페이지라고 생각해서, pages폴더 내에 search폴더를 만들고 그 안에 검색창의 전체적인 틀을 설정하였습니다. 검색결과는 SearchUserList 따로 컴포넌트로 분리하였습니다. 구조적으로 괜찮은지 봐주시면 감사하겠습니다 :)
- 스타일 부분에서 수정할 부분은 없는지 봐주시면 감사하겠습니다 :) 


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
