### PR TITLE
feat: user 컴포넌트 UI 구현 및 팔로우 버튼 컴포넌트화

### DIFF
--- a/src/components/button/FollowBtn/FollowBtn.jsx
+++ b/src/components/button/FollowBtn/FollowBtn.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useState } from 'react';
+import * as S from './followBtn.style';
+export default function FollowBtn({ ...props }) {
+  //추후에 팔로우 상태 서버에서 받아오기
+  const [isFollow, setIsFollow] = useState(false);
+  const handleFollowBtn = () => {
+    setIsFollow(!isFollow);
+  };
+  return (
+    <S.FollowBtn
+      alt="팔로우 버튼"
+      isFollow={isFollow}
+      onClick={handleFollowBtn}
+      size={props.size}
+    />
+  );
+}

--- a/src/components/button/FollowBtn/followBtn.style.jsx
+++ b/src/components/button/FollowBtn/followBtn.style.jsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+import { css } from 'styled-components';
+export const FollowBtn = styled.button`
+  ${(props) =>
+    //size가 small일 경우
+    props.size === 'small'
+      ? css`
+          &::after {
+            font-size: 1.2rem;
+            ${(props) =>
+              props.isFollow
+                ? css`
+                    content: '취소';
+                    color: ${props.theme.palette['mediumGray']};
+                  `
+                : css`
+                    content: '팔로우';
+                    color: ${props.theme.palette['white']};
+                  `};
+          }
+          ${(props) =>
+            props.isFollow
+              ? css`
+                  background-color: ${props.theme.palette['white']};
+                  border: 1px solid ${props.theme.palette['border']};
+                `
+              : css`
+                  background-color: ${props.theme.palette['point']};
+                  border: none;
+                `}
+          padding: 0.7rem 1.2rem;
+        `
+      : //size가 large일 경우
+        css`
+          &::after {
+            font-size: 1.4rem;
+            ${(props) =>
+              props.isFollow
+                ? css`
+                    content: '언팔로우';
+                    color: ${props.theme.palette['mediumGray']};
+                  `
+                : css`
+                    content: '팔로우';
+                    color: ${props.theme.palette['white']};
+                  `};
+          }
+          ${(props) =>
+            props.isFollow
+              ? css`
+                  background-color: ${props.theme.palette['white']};
+                  border: 1px solid ${props.theme.palette['darkGray']};
+                `
+              : css`
+                  background-color: ${props.theme.palette['point']};
+                  border: none;
+                `}
+          padding: 0.8rem 4.2rem;
+        `}
+  border-radius: 2.6rem;
+`;

--- a/src/components/userComponent/UserComponent.jsx
+++ b/src/components/userComponent/UserComponent.jsx
@@ -14,18 +14,14 @@ export default function UserComponent({ image, username, accountname }) {
         <S.UserName>{username}</S.UserName>
         <S.UserIntro>{accountname}</S.UserIntro>
       </S.UserInfo>
-      {/*페이지의 경로에 follow 있을 때 팔로우 버튼이 뜬다*/}
+      {/*페이지의 경로에 follow 있을 때 팔로우 버튼이 뜬다, search,follow 페이지가 아닐경우 모달 버튼이 뜬다*/}
       {path.includes('follow') ? (
         <FollowBtn size="small" />
       ) : (
-        {
-          /*페이지의 경로에 follow,search가 없을 때 모달 버튼이 뜬다*/
-        }(
-          !path.includes('search') && (
-            <ModalBtn>
-              <ProductModalContent />
-            </ModalBtn>
-          ),
+        !path.includes('search') && (
+          <ModalBtn>
+            <ProductModalContent />
+          </ModalBtn>
         )
       )}
     </S.UserComponent>

--- a/src/components/userComponent/UserComponent.jsx
+++ b/src/components/userComponent/UserComponent.jsx
@@ -3,14 +3,10 @@ import { useState } from 'react';
 import * as S from './userComponent.style';
 import ModalBtn from '../modal/ModalBtn/ModalBtn';
 import ProductModalContent from '../modal/modalContent/PostModalContent/PostModalContent';
+import FollowBtn from '../button/FollowBtn/FollowBtn';
+
 export default function UserComponent({ image, username, accountname }) {
   const path = window.location.href;
-  //추후에 팔로우 상태 서버에서 받아오기
-  const [isFollow, setIsFollow] = useState(false);
-  const handleFollowBtn = () => {
-    setIsFollow(!isFollow);
-  };
-
   return (
     <S.UserComponent>
       <S.ProfileImg src={image} alt="프로필이미지" />
@@ -20,11 +16,7 @@ export default function UserComponent({ image, username, accountname }) {
       </S.UserInfo>
       {/*페이지의 경로에 follow 있을 때 팔로우 버튼이 뜬다*/}
       {path.includes('follow') ? (
-        <S.FollowBtn
-          alt="팔로우 버튼"
-          isFollow={isFollow}
-          onClick={handleFollowBtn}
-        />
+        <FollowBtn size="small" />
       ) : (
         {
           /*페이지의 경로에 follow,search가 없을 때 모달 버튼이 뜬다*/

--- a/src/components/userComponent/UserComponent.jsx
+++ b/src/components/userComponent/UserComponent.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useState } from 'react';
+import * as S from './userComponent.style';
+import ModalBtn from '../modal/ModalBtn/ModalBtn';
+import ProductModalContent from '../modal/modalContent/PostModalContent/PostModalContent';
+export default function UserComponent({ image, username, accountname }) {
+  const path = window.location.href;
+  //추후에 팔로우 상태 서버에서 받아오기
+  const [isFollow, setIsFollow] = useState(false);
+  const handleFollowBtn = () => {
+    setIsFollow(!isFollow);
+  };
+
+  return (
+    <S.UserComponent>
+      <S.ProfileImg src={image} alt="프로필이미지" />
+      <S.UserInfo>
+        <S.UserName>{username}</S.UserName>
+        <S.UserIntro>{accountname}</S.UserIntro>
+      </S.UserInfo>
+      {/*페이지의 경로에 follow 있을 때 팔로우 버튼이 뜬다*/}
+      {path.includes('follow') ? (
+        <S.FollowBtn
+          alt="팔로우 버튼"
+          isFollow={isFollow}
+          onClick={handleFollowBtn}
+        />
+      ) : (
+        {
+          /*페이지의 경로에 follow,search가 없을 때 모달 버튼이 뜬다*/
+        }(
+          !path.includes('search') && (
+            <ModalBtn>
+              <ProductModalContent />
+            </ModalBtn>
+          ),
+        )
+      )}
+    </S.UserComponent>
+  );
+}

--- a/src/components/userComponent/userComponent.style.jsx
+++ b/src/components/userComponent/userComponent.style.jsx
@@ -20,33 +20,6 @@ export const ProfileImg = styled.img`
   border-radius: 50%;
 `;
 
-export const FollowBtn = styled.button`
-  &::after {
-    ${(props) =>
-      props.isFollow
-        ? css`
-            content: '취소';
-            color: ${props.theme.palette['mediumGray']};
-          `
-        : css`
-            content: '팔로우';
-            color: ${props.theme.palette['white']};
-          `};
-  }
-  ${(props) =>
-    props.isFollow
-      ? css`
-          background-color: ${props.theme.palette['white']};
-          border: 1px solid ${props.theme.palette['border']};
-        `
-      : css`
-          background-color: ${props.theme.palette['point']};
-          border: none;
-        `}
-  padding: 0.7em 1.2em;
-  border-radius: 2.6rem;
-`;
-
 export const UserInfo = styled.div`
   margin: 0.6em auto 0.7em 1.2em;
 `;

--- a/src/components/userComponent/userComponent.style.jsx
+++ b/src/components/userComponent/userComponent.style.jsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { css } from 'styled-components';
+
+export const UserComponent = styled(Link).attrs({
+  to: '#',
+})`
+  display: flex;
+  align-items: center;
+  //UserComponent 사이즈 조절을 위한 속성
+  font-size: 1rem;
+  & > * {
+    flex-shrink: 0;
+  }
+`;
+
+export const ProfileImg = styled.img`
+  width: 5em;
+  height: 5em;
+  border-radius: 50%;
+`;
+
+export const FollowBtn = styled.button`
+  &::after {
+    ${(props) =>
+      props.isFollow
+        ? css`
+            content: '취소';
+            color: ${props.theme.palette['mediumGray']};
+          `
+        : css`
+            content: '팔로우';
+            color: ${props.theme.palette['white']};
+          `};
+  }
+  ${(props) =>
+    props.isFollow
+      ? css`
+          background-color: ${props.theme.palette['white']};
+          border: 1px solid ${props.theme.palette['border']};
+        `
+      : css`
+          background-color: ${props.theme.palette['point']};
+          border: none;
+        `}
+  padding: 0.7em 1.2em;
+  border-radius: 2.6rem;
+`;
+
+export const UserInfo = styled.div`
+  margin: 0.6em auto 0.7em 1.2em;
+`;
+
+export const UserName = styled.strong`
+  display: block;
+  font-size: 1.4em;
+  margin-bottom: 0.6em;
+`;
+
+export const UserIntro = styled.strong`
+  display: block;
+  font-size: 1.2em;
+  color: ${(props) => props.theme.palette['mediumGray']};
+`;


### PR DESCRIPTION
### 작업 내역

- 유저 컴포넌트 UI를 구현하였습니다
- 팔로우 버튼을 컴포넌트화 했습니다

### 작업 후 기대 동작(스크린샷)
<img width="499" alt="image" src="https://user-images.githubusercontent.com/89335150/179355507-5e1c10f5-e147-45f7-8715-f772dd030b31.png">

- 유저 컴포넌트의 경우 페이지의 경로에 follow 있을 때 팔로우 버튼이 뜨고, 페이지 경로가 follow, search가 아닌 경우 modal 버튼이 뜹니다.
-  작은 팔로우 버튼 `<FollowBtn size="small" />`
-  큰 팔로우 버튼 `<FollowBtn size="large" />`


### PR 특이 사항

- 특이 사항 : - 

### Issue Number 

close: #27

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

- 유저 컴포넌트의 스타일은 특정한 요소들을 제외하곤 em 단위로 구현하여 최상위 컴포넌트의 폰트 사이즈(1rem)에 따라 조절이 가능하도록 구현했습니다. 이 부분도 나중에 이슈가 되진 않을지 검토부탁드립니다. 
- 추후에 버튼은 스타일별, 내용별로 모두 컴포넌트화를 하려고 합니다. 우선 급한 팔로우 버튼만 컴포넌트화 하였습니다. 팔로우 버튼의 스타일 컴포넌트가 조금 복잡한데, 어떻게 더 개선할 수 있을지 의견이 듣고싶습니다.


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
