### PR TITLE
feat: 로그인기능 구현

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -20,12 +20,16 @@ function Login() {
           password: password,
         },
       });
+      console.log(res);
 
       if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
+        console.log(res.data.message);
         setMessage('이메일 또는 비밀번호가 일치하지 않습니다.');
+      } else {
+        setMessage('');
+        console.log(res.data.user.token);
+        localStorage.setItem('Access Token', res.data.user.token);
       }
-      console.log(res);
-      console.log(res.data.message);
     } catch (error) {
       console.log(error);
     }

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as S from './login.style';
-import LoginButton from './../../assets/Login-Disabled-button.svg';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 
@@ -10,32 +9,47 @@ function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
+  const [ableToClick, setAbleToClick] = useState(false);
+
   const [message, setMessage] = useState('');
 
-  async function login() {
-    try {
-      const res = await axios.post('http://146.56.183.55:5050/user/login', {
-        headers: {
-          'Content-type': 'application/json',
-        },
-        user: {
-          email: email,
-          password: password,
-        },
-      });
-      console.log(res);
+  // email과 password가 둘 다 빈값이 아닐 때 setAbleToClick true로 변경
+  useEffect(() => {
+    if (email && password) {
+      setAbleToClick(true);
+    } else {
+      setAbleToClick(false);
+    }
+  }, [email, password]);
 
-      if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
-        console.log(res.data.message);
-        setMessage('이메일 또는 비밀번호가 일치하지 않습니다.');
-      } else {
-        setMessage('');
-        console.log(res.data.user.token);
-        localStorage.setItem('Access Token', res.data.user.token);
-        navigate('/home');
+  async function login() {
+    console.log(ableToClick);
+    // email, password가 둘 다 빈 값이 아닐때(true일 때)만 실행
+    if (ableToClick === true) {
+      try {
+        const res = await axios.post('http://146.56.183.55:5050/user/login', {
+          headers: {
+            'Content-type': 'application/json',
+          },
+          user: {
+            email: email,
+            password: password,
+          },
+        });
+        console.log(res);
+
+        if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
+          console.log(res.data.message);
+          setMessage('이메일 또는 비밀번호가 일치하지 않습니다.');
+        } else {
+          setMessage('');
+          console.log(res.data.user.token);
+          localStorage.setItem('Access Token', res.data.user.token);
+          navigate('/home');
+        }
+      } catch (error) {
+        console.log(error);
       }
-    } catch (error) {
-      console.log(error);
     }
   }
 
@@ -59,7 +73,9 @@ function Login() {
             onChange={(e) => setPassword(e.target.value)}
           />
           <p className="message">{message}</p>
-          <img src={LoginButton} alt="login button" onClick={login} />
+          <S.Button onClick={login} type="button" ableToClick={ableToClick}>
+            로그인
+          </S.Button>
         </S.FormBox>
       </form>
       <p>이메일로 회원가입</p>

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -2,8 +2,11 @@ import React, { useState } from 'react';
 import * as S from './login.style';
 import LoginButton from './../../assets/Login-Disabled-button.svg';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 function Login() {
+  const navigate = useNavigate();
+
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -29,6 +32,7 @@ function Login() {
         setMessage('');
         console.log(res.data.user.token);
         localStorage.setItem('Access Token', res.data.user.token);
+        navigate('/home');
       }
     } catch (error) {
       console.log(error);

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -78,7 +78,7 @@ function Login() {
           </S.Button>
         </S.FormBox>
       </form>
-      <p>이메일로 회원가입</p>
+      <S.StyledLink to={'/signin'}>이메일로 회원가입</S.StyledLink>
     </S.Wrapper>
   );
 }

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -7,6 +7,8 @@ function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
+  const [message, setMessage] = useState('');
+
   async function login() {
     try {
       const res = await axios.post('http://146.56.183.55:5050/user/login', {
@@ -18,8 +20,12 @@ function Login() {
           password: password,
         },
       });
+
+      if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
+        setMessage('이메일 또는 비밀번호가 일치하지 않습니다.');
+      }
       console.log(res);
-      console.log(res.data);
+      console.log(res.data.message);
     } catch (error) {
       console.log(error);
     }
@@ -39,11 +45,12 @@ function Login() {
           />
           <label htmlFor="password">비밀번호</label>
           <input
-            type="text"
+            type="password"
             id="passWord"
             name="password"
             onChange={(e) => setPassword(e.target.value)}
           />
+          <p className="message">{message}</p>
           <img src={LoginButton} alt="login button" onClick={login} />
         </S.FormBox>
       </form>

--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -9,18 +9,15 @@ function Login() {
 
   async function login() {
     try {
-      const res = await axios.post(
-        'https://mandarin.api.weniv.co.kr/user/login',
-        {
-          headers: {
-            'Content-type': 'application/json',
-          },
-          user: {
-            email: email,
-            password: password,
-          },
+      const res = await axios.post('http://146.56.183.55:5050/user/login', {
+        headers: {
+          'Content-type': 'application/json',
         },
-      );
+        user: {
+          email: email,
+          password: password,
+        },
+      });
       console.log(res);
       console.log(res.data);
     } catch (error) {

--- a/src/components/login/login.style.jsx
+++ b/src/components/login/login.style.jsx
@@ -33,6 +33,7 @@ export const FormBox = styled.div`
   }
 
   & > input {
+    width: 32.2rem;
     border: none;
     outline: none;
     font-size: 1.4rem;
@@ -40,11 +41,11 @@ export const FormBox = styled.div`
     border-bottom: 0.1rem solid ${(props) => props.theme.palette['border']};
   }
 
-  & > img {
+  /* & > img {
     margin-top: 1.4rem;
     margin-bottom: 2.1rem;
     cursor: pointer;
-  }
+  } */
 
   .message {
     font-size: 1.2rem;
@@ -53,4 +54,20 @@ export const FormBox = styled.div`
     margin-top: -1rem;
     color: ${(props) => props.theme.palette['point']};
   }
+`;
+
+export const Button = styled.div`
+  margin-top: 1.6rem;
+  background-color: ${(props) =>
+    props.ableToClick === true
+      ? props.theme.palette['primary']
+      : props.theme.palette['disabled']};
+  font-size: 1.4rem;
+  font-weight: 500;
+  padding: 1.3rem 0 1.4rem 0;
+  text-align: center;
+  border-radius: 44px;
+  margin-bottom: 2.1rem;
+  cursor: ${(props) =>
+    props.ableToClick === true ? 'pointer' : 'not-allowed'};
 `;

--- a/src/components/login/login.style.jsx
+++ b/src/components/login/login.style.jsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 export const Wrapper = styled.div`
   width: 390px;
@@ -22,6 +23,12 @@ export const Wrapper = styled.div`
   }
 `;
 
+export const StyledLink = styled(Link)`
+  font-size: 1.2rem;
+  font-weight: 400;
+  color: ${(props) => props.theme.palette['darkGray']};
+`;
+
 export const FormBox = styled.div`
   display: flex;
   flex-direction: column;
@@ -40,12 +47,6 @@ export const FormBox = styled.div`
     margin-bottom: 1.6rem;
     border-bottom: 0.1rem solid ${(props) => props.theme.palette['border']};
   }
-
-  /* & > img {
-    margin-top: 1.4rem;
-    margin-bottom: 2.1rem;
-    cursor: pointer;
-  } */
 
   .message {
     font-size: 1.2rem;

--- a/src/components/login/login.style.jsx
+++ b/src/components/login/login.style.jsx
@@ -45,4 +45,12 @@ export const FormBox = styled.div`
     margin-bottom: 2.1rem;
     cursor: pointer;
   }
+
+  .message {
+    font-size: 1.2rem;
+    font-weight: 500;
+    margin-bottom: 1.6rem;
+    margin-top: -1rem;
+    color: ${(props) => props.theme.palette['point']};
+  }
 `;

--- a/src/components/login/login.style.jsx
+++ b/src/components/login/login.style.jsx
@@ -41,6 +41,7 @@ export const FormBox = styled.div`
 
   & > input {
     width: 32.2rem;
+    line-height: 2.5rem;
     border: none;
     outline: none;
     font-size: 1.4rem;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 로그인기능 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 로그인기능 구현

### 작업 내역

- useEffect사용하여 eamil, password 둘 다 빈값이 아닐 때 setAbleToClick true로 변경
- setAbleToClick이 true일 때 -> 로그인버튼 색깔 primary로 변경, cursor pointer로 변경, 서버전송
- setAbleToClick이 false일 때 -> 로그인버튼 색깔 disabled로 변경, cursor not-allowed로 변경, 서버전송 일어나지 않음
- 서버 응답 메세지가 '이메일 또는 비밀번호가 일치하지 않습니다.'가 아닌경우 로컬스토리지에 Access Token 이름으로 user token 저장
- 서버 응답 메세지가 '이메일 또는 비밀번호가 일치하지 않습니다.'인 경우 메세지 출력
- 로그인 성공시 /home 으로 이동
- '이메일로 회원가입하기' 클릭시 회원가입 페이지로 이동

### 작업 후 기대 동작(스크린샷)

- 이메일/비밀번호 아무것도 입력하지 않을 시 로그인버튼 비활성화/서버전송되지않음
<img width="401" alt="image" src="https://user-images.githubusercontent.com/95600994/179392031-af400ba2-6f4e-48e1-8f44-66dd1787cb33.png">

- 제대로 입력 안할시 메세지 출력
<img width="397" alt="image" src="https://user-images.githubusercontent.com/95600994/179392049-7bf45bc6-3e08-4f8b-95d6-8387df058f2b.png">

- 제대로 입력시 홈으로 이동
<img width="316" alt="image" src="https://user-images.githubusercontent.com/95600994/179392078-316e4af0-302e-4686-805c-c528645d8346.png">

- 로그인 성공시 로컬스토리지에 토큰 저장
<img width="666" alt="image" src="https://user-images.githubusercontent.com/95600994/179392108-5cbe15bb-04d1-453c-a9b0-11de1c995ac6.png">


### PR 특이 사항

- 없음

### Issue Number 

close: #16 #1 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 토큰에 대해서 더 처리할게 있는지?
- 예외처리가 잘 된건지?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
