### PR TITLE
[feat] 게시글 이미지 미리보기 기능구현

### DIFF
--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -42,7 +42,7 @@ function PostUpload() {
           <S.PostUploadLegendTxt className="A11yHidden">
             게시글을 입력하세요
           </S.PostUploadLegendTxt>
-          <textarea
+          <S.PostUploadTextarea
             name="postTxt"
             id="postTxt"
             type="text"

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import * as S from './postUpload.style';
+import { useRef, useState } from 'react';
 import UploadHeader from '../header/UploadHeader/UploadHeader';
 
 function PostUpload() {
+  const Upload_Input = useRef();
   const [text, setText] = useState(''); //입력텍스트
+  const [imageUrl, setImageUrl] = useState('');
 
   //입력창에 글을 쓰면 이벤트발생
   const handleChangeText = (e) => {
@@ -37,12 +40,19 @@ function PostUpload() {
             </S.UploadImg>
             <S.UploadInput
               className="A11yHidden"
-              // ref={Upload_Input}
+              ref={Upload_Input}
               type="file"
               accept="image/*"
               // onChange={handleChangeFile}
             />
-            <S.ImgUploadBtn />
+            <S.ImgUploadBtn
+              onClick={
+                () =>
+                  imageUrl.length === 3
+                    ? alert('이미지는 3개까지만 업로드할 수 있습니다.')
+                    : Upload_Input.current.click() //이 버튼을 클릭하면 file input을 클릭한겁니다.이벤트위임을 받았다
+              }
+            />
           </S.PostFormContainer>
         </S.PostForm>
       </S.PostUploadFieldSet>

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -30,11 +30,12 @@ function PostUpload() {
             </S.UploadImg>
             <S.UploadInput
               className="A11yHidden"
-              ref={Upload_Input}
+              // ref={Upload_Input}
               type="file"
               accept="image/*"
               // onChange={handleChangeFile}
             />
+            <S.ImgUploadBtn />
           </S.PostFormContainer>
         </S.PostForm>
       </S.PostUploadFieldSet>

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -13,6 +13,23 @@ function PostUpload() {
     setText(e.target.value);
   };
 
+  //이미지 미리보기
+  const handleChangeFile = (e) => {
+    const Blob = e.target.files[0];
+    if (Blob === undefined) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.readAsDataURL(Blob);
+    e.target.value = '';
+    return new Promise((resolve) => {
+      reader.onload = () => {
+        setImageUrl((imageUrl) => [...imageUrl, reader.result]);
+        resolve();
+      };
+    });
+  };
+
   return (
     <S.PostUploadWrapper>
       <UploadHeader />
@@ -34,7 +51,9 @@ function PostUpload() {
             placeholder={'게시글 입력하기...'}
           />
           <S.PostFormContainer>
-            <S.PreviewImage src="" alt="" />
+            {imageUrl && (
+              <S.PreviewImage src={imageUrl} alt="이미지 미리보기" />
+            )}
             <S.UploadImg className="A11yHidden">
               게시글 이미지 업로드
             </S.UploadImg>
@@ -43,7 +62,7 @@ function PostUpload() {
               ref={Upload_Input}
               type="file"
               accept="image/*"
-              // onChange={handleChangeFile}
+              onChange={handleChangeFile}
             />
             <S.ImgUploadBtn
               onClick={

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -3,6 +3,13 @@ import * as S from './postUpload.style';
 import UploadHeader from '../header/UploadHeader/UploadHeader';
 
 function PostUpload() {
+  const [text, setText] = useState(''); //입력텍스트
+
+  //입력창에 글을 쓰면 이벤트발생
+  const handleChangeText = (e) => {
+    setText(e.target.value);
+  };
+
   return (
     <S.PostUploadWrapper>
       <UploadHeader />
@@ -19,7 +26,7 @@ function PostUpload() {
             name="postTxt"
             id="postTxt"
             type="text"
-            // onChange={handleChangeText}
+            onChange={handleChangeText}
             maxLength="200"
             placeholder={'게시글 입력하기...'}
           />

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -8,14 +8,14 @@ function PostUpload() {
     <S.PostUploadWrapper>
       <UploadHeader />
       <S.PostUploadFieldSet>
-        <A11yHidden>
-          <legend>게시글 작성 페이지</legend>
-        </A11yHidden>
+        <S.PostUploadLegend className="A11yHidden">
+          게시글 작성 페이지
+        </S.PostUploadLegend>
         <S.ProfileImage />
         <S.PostForm>
-          <A11yHidden>
-            <h4>게시글을 입력하세요</h4>
-          </A11yHidden>
+          <S.PostUploadLegendTxt className="A11yHidden">
+            게시글을 입력하세요
+          </S.PostUploadLegendTxt>
           <textarea
             name="postTxt"
             id="postTxt"
@@ -30,19 +30,16 @@ function PostUpload() {
                 <S.PreviewImage src="" alt="" />
               </S.PreviewImageItem>
             </S.PreviewImageList>
-            <A11yHidden>
-              <h4>게시글 이미지 업로드</h4>
-            </A11yHidden>
-            <S.UploadImgIcon htmlFor="fileInput" />
-            <A11yHidden>
-              <input
-                type="file"
-                className="PostUploadImageInput"
-                id="fileInput"
-                accept="image/*"
-                // onChange={handleChangeFile}
-              />
-            </A11yHidden>
+            <S.UploadImg className="A11yHidden">
+              게시글 이미지 업로드
+            </S.UploadImg>
+            <S.UploadInput
+              className="A11yHidden"
+              ref={Upload_Input}
+              type="file"
+              accept="image/*"
+              // onChange={handleChangeFile}
+            />
           </S.PostFormContainer>
         </S.PostForm>
       </S.PostUploadFieldSet>

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as S from './postUpload.style';
 import UploadHeader from '../header/UploadHeader/UploadHeader';
-import { A11yHidden } from '../../styles/common.style';
 
 function PostUpload() {
   return (
@@ -25,11 +24,7 @@ function PostUpload() {
             placeholder={'게시글 입력하기...'}
           />
           <S.PostFormContainer>
-            <S.PreviewImageList>
-              <S.PreviewImageItem>
-                <S.PreviewImage src="" alt="" />
-              </S.PreviewImageItem>
-            </S.PreviewImageList>
+            <S.PreviewImage src="" alt="" />
             <S.UploadImg className="A11yHidden">
               게시글 이미지 업로드
             </S.UploadImg>

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -51,9 +51,10 @@ function PostUpload() {
             placeholder={'게시글 입력하기...'}
           />
           <S.PostFormContainer>
-            {imageUrl && (
-              <S.PreviewImage src={imageUrl} alt="이미지 미리보기" />
-            )}
+            {imageUrl &&
+              imageUrl.map((index, key) => (
+                <S.PreviewImage key={key} src={index} alt="" />
+              ))}
             <S.UploadImg className="A11yHidden">
               게시글 이미지 업로드
             </S.UploadImg>

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -47,25 +47,6 @@ export const UploadImg = styled.h4``;
 
 export const UploadInput = styled.input``;
 
-export const PreviewImageList = styled.ul`
-  display: flex;
-  width: 100%;
-  gap: 1.2rem;
-  overflow-x: scroll;
-  overflow-y: hidden;
-`;
-
-export const PreviewImageItem = styled.li`
-  position: relative;
-  border-radius: 10px;
-  min-width: 30.4rem;
-  width: 30.4rem;
-  height: 22.8rem;
-  overflow: hidden;
-  border: 0.5px solid ${(props) => props.theme.palette['border']};
-  margin-right: 0.5rem;
-`;
-
 export const UploadImgIcon = styled.label`
   position: fixed;
   bottom: 1.6rem;

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -14,6 +14,10 @@ export const PostUploadFieldSet = styled.fieldset`
 
 export const PostUploadLegend = styled.legend``;
 
+export const PostUploadTextarea = styled.textarea`
+  margin-top: 1.2rem;
+`;
+
 export const PostUploadLegendTxt = styled.h4``;
 
 export const ProfileImage = styled.img.attrs({

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -39,6 +39,7 @@ export const PostForm = styled.article`
 `;
 
 export const PostFormContainer = styled.div`
+  display: flex;
   width: 100%;
   padding-top: 1.2rem;
 `;
@@ -62,7 +63,8 @@ export const ImgUploadBtn = styled.img.attrs({
 `;
 
 export const PreviewImage = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  margin: 10px 0 0 15px;
+  width: 200px;
+  height: auto;
+  border-radius: 10px;
 `;

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -12,6 +12,10 @@ export const PostUploadFieldSet = styled.fieldset`
   flex-direction: row;
 `;
 
+export const PostUploadLegend = styled.legend``;
+
+export const PostUploadLegendTxt = styled.h4``;
+
 export const ProfileImage = styled.img.attrs({
   src: basicProfile,
   alt: '프로필 이미지',
@@ -38,6 +42,10 @@ export const PostFormContainer = styled.div`
   width: 100%;
   padding-top: 1.2rem;
 `;
+
+export const UploadImg = styled.h4``;
+
+export const UploadInput = styled.input``;
 
 export const PreviewImageList = styled.ul`
   display: flex;

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -47,17 +47,18 @@ export const UploadImg = styled.h4``;
 
 export const UploadInput = styled.input``;
 
-export const UploadImgIcon = styled.label`
+export const ImgUploadBtn = styled.img.attrs({
+  src: uploadIcon,
+  alt: '이미지 업로드',
+})`
   position: fixed;
   bottom: 1.6rem;
   right: 1.6rem;
   width: 5rem;
   height: 5rem;
-  background-image: url(${uploadIcon});
-  background-position: center;
-  background-size: cover;
+  border-radius: 50%;
+  margin-right: 1.2rem;
   cursor: pointer;
-  z-index: 100;
 `;
 
 export const PreviewImage = styled.img`


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 게시글 이미지 미리보기 기능구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 사진은 우측 하단 버튼을 클릭하면 업로드할 수 있으며, 최대 3장까지 업로드 가능합니다.
- 3장이 넘어가면 alert창을 띄어줍니다. 
- 게시글을 입력할 수 있습니다.

### 작업 후 기대 동작(스크린샷)
![image](https://user-images.githubusercontent.com/102465469/179561537-d86e05c7-c0ac-4057-bdcf-c71866dc3ddc.png)
![image](https://user-images.githubusercontent.com/102465469/179561611-dd7745a3-99f8-43dd-a37c-215ba02e895f.png)


### PR 특이 사항

- 이미지 버튼 활성화, 이미지 업로드 전송은 다른 이슈로 남기겠습니다.

### Issue Number 

close: #35 


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
