### PR TITLE
feat: 하단 네비게이션 바 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React from 'react';
 import GlobalStyles from './styles/GlobalStyles';
 import { BrowserRouter } from 'react-router-dom';
 import Pages from './pages/Pages';
-import NavigationBar from './components/navigation-bar/NavigationBar';
 
 function App() {
   return (
@@ -10,7 +9,6 @@ function App() {
       <BrowserRouter>
         <GlobalStyles />
         <Pages />
-        <NavigationBar />
       </BrowserRouter>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import GlobalStyles from './styles/GlobalStyles';
 import { BrowserRouter } from 'react-router-dom';
 import Pages from './pages/Pages';
+import NavigationBar from './components/navigation-bar/NavigationBar';
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <BrowserRouter>
         <GlobalStyles />
         <Pages />
+        <NavigationBar />
       </BrowserRouter>
     </div>
   );

--- a/src/components/navigation-bar/NavigationBar.jsx
+++ b/src/components/navigation-bar/NavigationBar.jsx
@@ -50,6 +50,7 @@ function NavigationBar() {
   return (
     <Wrapper>
       <NavBar>
+        {/* 홈으로 이동 */}
         <StyleNavLink
           to={'/home'}
           className={({ isActive }) => (isActive ? 'active' : 'inactive')}
@@ -61,6 +62,8 @@ function NavigationBar() {
             <p>홈</p>
           </List>
         </StyleNavLink>
+
+        {/* 채팅으로 이동 (임시로 search페이지로 이동)*/}
         <StyleNavLink
           to={'/search'}
           className={({ isActive }) => (isActive ? 'active' : 'inactive')}
@@ -73,6 +76,8 @@ function NavigationBar() {
             />
             <p>채팅</p>
           </List>
+
+          {/* 게시물 작성 페이지로 이동 */}
         </StyleNavLink>
         {/* post upload 페이지에서는 네비게이션 바 사라짐 */}
         <StyleNavLink
@@ -86,6 +91,8 @@ function NavigationBar() {
             <p>게시물 작성</p>
           </List>
         </StyleNavLink>
+
+        {/* 프로필 페이지로 이동  (임시로 adoptPost페이지로 이동)*/}
         <StyleNavLink
           to={'/adoptPost'}
           className={({ isActive }) => (isActive ? 'active' : 'inactive')}

--- a/src/components/navigation-bar/NavigationBar.jsx
+++ b/src/components/navigation-bar/NavigationBar.jsx
@@ -1,55 +1,103 @@
 import React from 'react';
 import styled from 'styled-components';
-import tapHome from '../../assets/tab-icon-home.svg.svg';
+import tabHome from '../../assets/tab-icon-home.svg.svg';
 import tabMessage from '../../assets/tab-icon-message.svg.svg';
 import tabEdit from '../../assets/tab-icon-edit.svg.svg';
 import tabUser from '../../assets/tab-icon-user.svg.svg';
+import activeTabHome from '../../assets/tab-icon-home-color.svg.svg';
+import activeTabMessage from '../../assets/tab-icon-message-color.svg.svg';
+import activeTabEdit from '../../assets/tab-icon-edit-color.svg.svg';
+import activeTabUser from '../../assets/tab-icon-user-color.svg.svg';
+import { NavLink } from 'react-router-dom';
 
 const Wrapper = styled.div`
   margin-top: auto;
   width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 `;
 
-const FlexBox = styled.div`
+const NavBar = styled.ul`
   display: flex;
   justify-content: space-around;
   align-items: center;
 `;
 
-const FlexItem = styled.div`
+const StyleNavLink = styled(NavLink)`
+  color: ${(props) => props.theme.palette['mediumGray']};
+  font-weight: 400;
+  font-size: 1rem;
+
+  // NavLink가 active일 때 글씨색깔 변경
+  &.active {
+    color: ${(props) => props.theme.palette['point']};
+  }
+`;
+
+const List = styled.li`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  cursor: pointer;
 
-  & > p {
-    color: ${(props) => props.theme.palette['mediumGray']};
-    font-weight: 400;
-    font-size: 1rem;
+  & > img {
+    width: 2rem;
   }
 `;
 
 function NavigationBar() {
   return (
     <Wrapper>
-      <FlexBox>
-        <FlexItem>
-          <img src={tapHome} />
-          <p>홈</p>
-        </FlexItem>
-        <FlexItem>
-          <img src={tabMessage} />
-          <p>홈</p>
-        </FlexItem>
-        <FlexItem>
-          <img src={tabEdit} />
-          <p>홈</p>
-        </FlexItem>
-        <FlexItem>
-          <img src={tabUser} />
-          <p>홈</p>
-        </FlexItem>
-      </FlexBox>
+      <NavBar>
+        <StyleNavLink
+          to={'/home'}
+          className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+        >
+          <List>
+            <img
+              src={location.pathname === '/home' ? activeTabHome : tabHome}
+            />
+            <p>홈</p>
+          </List>
+        </StyleNavLink>
+        <StyleNavLink
+          to={'/search'}
+          className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+        >
+          <List>
+            <img
+              src={
+                location.pathname === '/search' ? activeTabMessage : tabMessage
+              }
+            />
+            <p>채팅</p>
+          </List>
+        </StyleNavLink>
+        {/* post upload 페이지에서는 네비게이션 바 사라짐 */}
+        <StyleNavLink
+          to={'/upload'}
+          className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+        >
+          <List>
+            <img
+              src={location.pathname === '/upload' ? activeTabEdit : tabEdit}
+            />
+            <p>게시물 작성</p>
+          </List>
+        </StyleNavLink>
+        <StyleNavLink
+          to={'/adoptPost'}
+          className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+        >
+          <List>
+            <img
+              src={location.pathname === '/adoptPost' ? activeTabUser : tabUser}
+            />
+            <p>프로필</p>
+          </List>
+        </StyleNavLink>
+      </NavBar>
     </Wrapper>
   );
 }

--- a/src/components/navigation-bar/NavigationBar.jsx
+++ b/src/components/navigation-bar/NavigationBar.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from 'styled-components';
+import tapHome from '../../assets/tab-icon-home.svg.svg';
+import tabMessage from '../../assets/tab-icon-message.svg.svg';
+import tabEdit from '../../assets/tab-icon-edit.svg.svg';
+import tabUser from '../../assets/tab-icon-user.svg.svg';
+
+const Wrapper = styled.div`
+  margin-top: auto;
+  width: 100%;
+`;
+
+const FlexBox = styled.div`
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+
+const FlexItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+
+  & > p {
+    color: ${(props) => props.theme.palette['mediumGray']};
+    font-weight: 400;
+    font-size: 1rem;
+  }
+`;
+
+function NavigationBar() {
+  return (
+    <Wrapper>
+      <FlexBox>
+        <FlexItem>
+          <img src={tapHome} />
+          <p>홈</p>
+        </FlexItem>
+        <FlexItem>
+          <img src={tabMessage} />
+          <p>홈</p>
+        </FlexItem>
+        <FlexItem>
+          <img src={tabEdit} />
+          <p>홈</p>
+        </FlexItem>
+        <FlexItem>
+          <img src={tabUser} />
+          <p>홈</p>
+        </FlexItem>
+      </FlexBox>
+    </Wrapper>
+  );
+}
+
+export default NavigationBar;

--- a/src/pages/home/Home.jsx
+++ b/src/pages/home/Home.jsx
@@ -4,6 +4,7 @@ import PostCard from '../../components/post/PostCard/PostCard';
 import * as S from './Home.style';
 import { ReactComponent as Logo } from './../../assets/symbol-logo-feed.svg';
 import MainHeader from './../../components/header/MainHeader/MainHeader';
+import NavigationBar from '../../components/navigation-bar/NavigationBar';
 
 const Home = () => {
   const [userToken, setUserToken] = useState();
@@ -56,6 +57,7 @@ const Home = () => {
           </div>
         </S.FeedEmptyWrap>
       )}
+      <NavigationBar />
     </>
   );
 };


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 하단 네비게이션 바 구현
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 하단 네비게이션 바 구현

### 작업 내역

- NavLink 연결하여 클릭시 해당 페이지로 이동
- 해당 페이지와 location pathname이 일치한다면 color이미지로 변경
- 해당 페이지와 location pathname이 일치하지 않는다면 일반 이미지(흑백)으로 변경
- NavLink className에 isActive를 파라미터로 받아 active상태라면 active 클래스 달아줌
- active일 때 color point색깔로 스타일링

### 작업 후 기대 동작(스크린샷)

- 탭 클릭시 해당 탭에 해당하는 페이지로 이동 / 이미지와 탭이름 색깔 변경
<img width="300" alt="image" src="https://user-images.githubusercontent.com/95600994/180643462-3e46741c-9bb5-4af2-89bb-526e784dfafb.png">

- 게시물 작성페이지로 이동시 하단 네비바는 보이지 않음
<img width="300" alt="image" src="https://user-images.githubusercontent.com/95600994/180643549-5f7ca8d9-4c46-4a0e-b55f-2f43c9cc5046.png">



### PR 특이 사항

- 현재 home으로 이동시에만 네비바가 나타나며, 
- 채팅 탭으로 이동시 임시로 /search 로 이동. 추후 채팅페이지 구현 완료되면 연결에정
- 프로필 탭으로 이동시 임시로 /adoptPost 로 이동. 추후 프로필페이지 구현 완료되면 연결예정
- width는 100% , margin-top auto로 지정해놓음. 아직 부모Wrapper의 width와 height가 없기때문에 추후 의논하여 Wrapper 지정해주면 하단에 붙을 예정

### Issue Number 

close: #67 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
- 추후에 탭 이동시 특정 유저에 해당하는 페이지로 이동해야 할 것 같은데 어떻게 할 지 의논 필요해보입니다.

<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
