### PR TITLE
[fix] navbar에서 '프로필' 버튼 클릭 시 로그인 전의 프로필이 뜨는 버그 수정

### DIFF
--- a/src/components/navigation-bar/NavigationBar.jsx
+++ b/src/components/navigation-bar/NavigationBar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import tabHome from '../../assets/tab-icon-home.svg.svg';
 import tabMessage from '../../assets/tab-icon-message.svg.svg';
@@ -9,8 +9,6 @@ import activeTabMessage from '../../assets/tab-icon-message-color.svg.svg';
 import activeTabEdit from '../../assets/tab-icon-edit-color.svg.svg';
 import activeTabUser from '../../assets/tab-icon-user-color.svg.svg';
 import { NavLink } from 'react-router-dom';
-
-const accountName = localStorage.getItem('Account Name');
 
 const Wrapper = styled.div`
   margin-top: auto;
@@ -53,6 +51,13 @@ const List = styled.li`
 `;
 
 function NavigationBar() {
+  const [accountName, setAccountName] = useState();
+
+  useEffect(() => {
+    const loggedInUser = localStorage.getItem('Account Name');
+    setAccountName(loggedInUser);
+  }, []);
+
   return (
     <Wrapper>
       <NavBar>


### PR DESCRIPTION
로그아웃 이전의 프로필이 뜨는 버그 수정

### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :  navbar에서 '프로필' 버튼 클릭 시 로그인 전의 프로필이 뜨는 버그 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

-  navbar에서 '프로필' 버튼 클릭 시, 다른 계정으로 로그인 했어도 로그인 전의 프로필이 뜨는 버그 발생.
- accountName을 const로 받아오고 있어서, 컴포넌트가 재렌더링될때 accountName은 다시 렌더되지 않아서 생기는 현상이었습니다. 

### 작업 내역

- NavigationBar내에서 컴포넌트가 마운트될때마다 accountName을 받아오도록 수정했습니다.


### Issue Number 

close: #

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
