### PR TITLE
[feat] 사용자 프로필 페이지 하단 피드 내 앨범형 피드 구현 

### DIFF
--- a/src/components/post/PostAlbumCard/PostAlbumCard.jsx
+++ b/src/components/post/PostAlbumCard/PostAlbumCard.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import * as S from './PostAlbumCard.style';
+
+const PostAlbumCard = ({ data }) => {
+  const singleImage = data.image.split(',').length === 0;
+
+  if (data.image.length !== 0) {
+    return (
+      <S.AlbumCardLinkLi>
+        <S.AlbumCardLink href={`/post/${data.id}`}>
+          <S.AlbumCardImg
+            src={singleImage ? data.image : data.image.split(',')[0]}
+          >
+            {console.log(data)}
+          </S.AlbumCardImg>
+        </S.AlbumCardLink>
+      </S.AlbumCardLinkLi>
+    );
+  }
+};
+
+export default PostAlbumCard;

--- a/src/components/post/PostAlbumCard/PostAlbumCard.style.jsx
+++ b/src/components/post/PostAlbumCard/PostAlbumCard.style.jsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const AlbumCardLinkLi = styled.li`
+  position: relative;
+  max-height: 114px;
+  min-height: 114px;
+  display: flex;
+`;
+
+export const AlbumCardLink = styled.a`
+  width: 100%;
+  height: 100%;
+`;
+
+export const AlbumCardImg = styled.img`
+  margin-bottom: 0;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/src/pages/userProfile/UserProfile.jsx
+++ b/src/pages/userProfile/UserProfile.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
 import PostCard from '../../components/post/PostCard/PostCard';
+import PostAlbumCard from '../../components/post/PostAlbumCard/PostAlbumCard';
 import BasicHeader from './../../components/header/BasicHeader/BasicHeader';
 import ProfileInfo from './../../components/profile/ProfileInfo/ProfileInfo';
 import AdoptSection from './../../components/adoptSection/AdoptSection';
@@ -104,7 +105,8 @@ const UserProfile = () => {
         )}
       </S.UserPostHeader>
       <S.UserPostWrap>
-        {userPostData &&
+        {!albumOn &&
+          userPostData &&
           userPostData.map((post) => {
             return (
               <S.ProfilePostCardWrap key={post.id}>
@@ -112,6 +114,13 @@ const UserProfile = () => {
               </S.ProfilePostCardWrap>
             );
           })}
+        <S.ProfilePostAlbumWrap>
+          {albumOn &&
+            userPostData &&
+            userPostData.map((post) => {
+              return <PostAlbumCard key={post.id} data={post} />;
+            })}
+        </S.ProfilePostAlbumWrap>
       </S.UserPostWrap>
       <NavigationBar />
     </S.UserProfileWrap>

--- a/src/pages/userProfile/UserProfile.jsx
+++ b/src/pages/userProfile/UserProfile.jsx
@@ -18,6 +18,7 @@ const UserProfile = () => {
   const [userPostData, setUserPostData] = useState();
   const [userProfileData, setUserProfileData] = useState();
   const [isAuthorized, setIsAuthorized] = useState(false);
+  const [albumOn, setAlbumOn] = useState(false);
   const params = useParams();
 
   useEffect(() => {
@@ -81,10 +82,26 @@ const UserProfile = () => {
       )}
       <AdoptSection accountName={params.id} />
       <S.UserPostHeader>
-        <S.UserPostBtnsWrap>
-          <PostIcoOn />
-          <AlbumIcoOff style={{ marginLeft: '1.6rem' }} />
-        </S.UserPostBtnsWrap>
+        {!albumOn ? (
+          <S.UserPostBtnsWrap>
+            <PostIcoOn />
+            <AlbumIcoOff
+              onClick={() => {
+                setAlbumOn(true);
+              }}
+              style={{ marginLeft: '1.6rem' }}
+            />
+          </S.UserPostBtnsWrap>
+        ) : (
+          <S.UserPostBtnsWrap>
+            <PostIcoOff
+              onClick={() => {
+                setAlbumOn(false);
+              }}
+            />
+            <AlbumIcoOn style={{ marginLeft: '1.6rem' }} />
+          </S.UserPostBtnsWrap>
+        )}
       </S.UserPostHeader>
       <S.UserPostWrap>
         {userPostData &&

--- a/src/pages/userProfile/UserProfile.style.jsx
+++ b/src/pages/userProfile/UserProfile.style.jsx
@@ -31,6 +31,9 @@ export const UserPostBtnsWrap = styled.div`
   width: 100%;
   height: 44px;
   padding-right: 16px;
+  & > * {
+    cursor: pointer;
+  }
 `;
 
 export const ProfilePostCardWrap = styled.div`

--- a/src/pages/userProfile/UserProfile.style.jsx
+++ b/src/pages/userProfile/UserProfile.style.jsx
@@ -10,6 +10,7 @@ export const UserProfileWrap = styled.main`
 export const UserPostWrap = styled.div`
   flex-wrap: wrap;
   justify-content: center;
+  align-items: center;
   background-color: ${(props) => props.theme.palette['white']};
 `;
 
@@ -38,4 +39,13 @@ export const UserPostBtnsWrap = styled.div`
 
 export const ProfilePostCardWrap = styled.div`
   padding: 1.6rem 1.6rem 0 1.6rem;
+`;
+
+export const ProfilePostAlbumWrap = styled.ul`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  max-width: 39rem;
+  margin: 0 auto;
+  padding: 1.6rem 0;
 `;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 사용자 프로필 페이지 하단 피드 내 앨범형 피드 구현 
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- 하단 피드내 앨범 버튼 클릭 시, 앨범형으로 게시글이 표시되도록 구현했습니다

### 작업 후 기대 동작(스크린샷)

- 앨범 버튼 클릭 시, 이미지가 있는 게시글들만 앨범형으로 표시
![image](https://user-images.githubusercontent.com/90305737/180937789-e8b04642-11da-443f-a2d2-e69fa072ed49.png)
-피드 버튼 클릭 시 버튼 토글 및 기존 피드형으로 표시
![image](https://user-images.githubusercontent.com/90305737/180937799-c8622c09-3224-4efc-a34e-2f56c1a1ffe3.png)

### Issue Number 

close: #77 

<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
