### PR TITLE
bug: chatHeader navigate 경로 chats로 변경

### DIFF
--- a/src/components/header/ChatHeader/ChatHeader.jsx
+++ b/src/components/header/ChatHeader/ChatHeader.jsx
@@ -7,7 +7,7 @@ import ChatModalContent from '../../modal/modalContent/ChatModalContent/ChatModa
 export default function ChatHeader({ name }) {
   const navigate = useNavigate();
   const handleGoPrev = () => {
-    navigate(-1);
+    navigate('/chats');
   };
   return (
     <BasicHeaderLayout>


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : chatHeader navigate 경로 chats로 변경
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- chatHeader navigate 경로를 (-1)로 설정하니, 올바른 chat경로가 아닌 다른 경로로 이동하는 오류 발생

### 작업 내역

![화면 기록 2022-07-26 오후 10 10 03](https://user-images.githubusercontent.com/89335150/181014388-a1e33bad-0eaa-45be-a14a-43c06e0444a9.gif)



- chatHeader navigate 경로 chats로 변경

### 작업 후 기대 동작(스크린샷)

- 올바른 경로로 이동

### PR 특이 사항

- 없습니다

### Issue Number 

close: #101 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
