### PR TITLE
[fix] profileImage가 default일때 표시되는 이미지 수정

### DIFF
--- a/src/components/sign-in/SetProfile.jsx
+++ b/src/components/sign-in/SetProfile.jsx
@@ -103,7 +103,9 @@ function SetProfile() {
           password: password,
           accountname: userID,
           intro: userIntro,
-          image: profileImage,
+          image: profileImage
+            ? profileImage
+            : 'https://mandarin.api.weniv.co.kr/1658886785881.png',
         },
       });
       console.log(res.data);


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 :
- [ ] 리펙토링 :  profileImage가 default일때 표시되는 이미지 수정
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

-  사용자 프로필 이미지가 default일때, 경로가 올바르지 않아 엑박이 뜨는 이슈가 있었습니다. profileImage 변수가 존재하지 않을 때 표시되는 이미지의 경로를 수정했습니다

### 어떤 부분에 리뷰어가 집중하면 좋을까요?
이미지 경로가 wenive 서버에 의존하고 있기 때문에, public의 파일로 교체한다든지 추가 리팩토링이 이루어지면 좋을 것 같습니다 :)


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
