### PR TITLE
[bug] 이미지업로드 파일 형식 변경

### DIFF
--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -154,7 +154,7 @@ function PostUpload() {
               className="A11yHidden"
               ref={Upload_Input}
               type="file"
-              accept="image/*"
+              accept=".jpg, .gif, .png, .jpeg, .bmp, .tif, .heic"
               onChange={handleChangeFile}
             />
             <S.ImgUploadBtn


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [] 신규 기능 추가 : 
- [x] 버그 수정 : 이미지 업로드 파일 형식 변경
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- webp형식 파일 올리면 이미지에 엑박이 떴습니다(서버에서 지원하지 않기때문입니다)

### 작업 내역

- accept 속성으로 서버가 허용하는 형식만 기입합니다 

### 작업 후 기대 동작(스크린샷)

- 이미지 업로드를 클릭했을 때 webq가 선택되지 않게 안뜹니다


### Issue Number 

close: #113 



<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
