### PR TITLE
fix: 댓글 게시버튼 비활성화 오류 수정

### DIFF
--- a/src/components/comment/CommentReply/CommentReply.jsx
+++ b/src/components/comment/CommentReply/CommentReply.jsx
@@ -67,6 +67,7 @@ function CommentReply({ getComments, postId }) {
     }).then((response) => {
       console.log(response.data.result);
       setComment('');
+      setIsValid(false);
       getComments();
     });
   };


### PR DESCRIPTION


### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [] 신규 기능 추가 :
- [x] 버그 수정 : 댓글 게시버튼 비활성화 오류 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

-  댓글을 작성하고 게시 버튼을 누르면 게시 버튼이 비활성화(색상)로 바뀌어야 하는데 안바뀌는 문제 발생 


### 작업 내역

- 서버에 post를 보낸 후 setIsValid(false); 로 상태 값 추가 합니다

### 작업 후 기대 동작(스크린샷)
![Honeycam 2022-07-27 16-58-54](https://user-images.githubusercontent.com/102465469/181194051-2bfd55b8-97ce-4db2-b5e8-6579c9f6fd20.gif)

- 댓글 작성 후, 게시 버튼을 누르면 댓글이 업로드 되고 게시 버튼이 다시 비활성화로 바뀝니다

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #121 



<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
