### PR TITLE
[feat] 게시물 이미지 업로드 삭제 기능 구현

### DIFF
--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -112,6 +112,14 @@ function PostUpload() {
     }
   }
 
+  const deleteImg = (index) => {
+    const imgArr = image.filter((image, i) => i !== index);
+    const imgNameArr = imageUrl.filter((image, i) => i !== index);
+
+    setImgfile([...imgArr]);
+    setImageUrl([...imgNameArr]);
+  };
+
   return (
     <S.PostUploadWrapper
       method="POST"
@@ -142,9 +150,17 @@ function PostUpload() {
           />
           <S.PostFormContainer>
             {imageUrl &&
-              imageUrl.map((index, key) => (
-                <S.PreviewImage key={key} src={index} alt="" />
-              ))}
+              imageUrl.map((image, i) => {
+                return (
+                  <S.Item key={i}>
+                    <S.PreviewImage key={i} src={image} alt="이미지 미리보기" />
+                    <S.ImageDeleteBtn
+                      type="button"
+                      onClick={() => deleteImg(i)}
+                    />
+                  </S.Item>
+                );
+              })}
             <S.UploadImg className="A11yHidden">
               게시글 이미지 업로드
             </S.UploadImg>

--- a/src/components/postUpload/PostUpload.jsx
+++ b/src/components/postUpload/PostUpload.jsx
@@ -146,7 +146,7 @@ function PostUpload() {
             type="text"
             onChange={handleChangeText}
             maxLength="200"
-            placeholder={'게시글 입력하기...'}
+            placeholder={'게시글을 입력해주세요...'}
           />
           <S.PostFormContainer>
             {imageUrl &&

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -17,6 +17,9 @@ export const PostUploadLegend = styled.legend``;
 
 export const PostUploadTextarea = styled.textarea`
   margin-top: 1.2rem;
+  overflow-y: auto;
+  min-height: 7em;
+  word-break: break-all;
 `;
 
 export const PostUploadLegendTxt = styled.h4``;

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import uploadIcon from '../../assets/upload-file.svg';
 import basicProfile from '../../assets/basic-profile.svg';
+import ImageDelete from '../../assets/x.svg';
 
 export const PostUploadWrapper = styled.form`
   width: 100%;
@@ -71,9 +72,24 @@ export const ImgUploadBtn = styled.img.attrs({
   cursor: pointer;
 `;
 
+export const Item = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
 export const PreviewImage = styled.img`
+  position: relative;
   margin: 10px 0 0 15px;
   width: 200px;
   height: auto;
   border-radius: 10px;
+`;
+
+export const ImageDeleteBtn = styled.button`
+  position: absolute;
+  top: 1.8rem;
+  right: 0.6rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  background: url(${ImageDelete}) no-repeat center / contain;
 `;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 게시물 이미지 업로드 삭제 기능 
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 


### 작업 내역

- 이미지 삭제 버튼을 추가했습니다
- onChange 이벤트 함수의 인자로 index를 전달해주고, 해당 index와 같지 않은 요소를 새로운 배열로 반환하여 state에 담아주었습니다

### 작업 후 기대 동작(스크린샷)

![Honeycam 2022-07-29 19-00-59](https://user-images.githubusercontent.com/102465469/181735662-15ed9feb-674f-4ebc-bdb0-34cab378c074.gif)

- 삭제 버튼을 클릭하면 이미지가 삭제됩니다

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #130 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
