### PR TITLE
[refactor] 게시물 업로드 이미지 반응형 적용

### DIFF
--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -74,7 +74,6 @@ export const ImgUploadBtn = styled.img.attrs({
   width: 5rem;
   height: 5rem;
   border-radius: 50%;
-  margin-right: 1.2rem;
   cursor: pointer;
 `;
 

--- a/src/components/postUpload/postUpload.style.jsx
+++ b/src/components/postUpload/postUpload.style.jsx
@@ -55,6 +55,9 @@ export const PostFormContainer = styled.div`
   display: flex;
   width: 100%;
   padding-top: 1.2rem;
+  @media screen and (max-width: 420px) {
+    flex-direction: column;
+  }
 `;
 
 export const UploadImg = styled.h4``;
@@ -81,11 +84,14 @@ export const Item = styled.div`
 `;
 
 export const PreviewImage = styled.img`
-  position: relative;
   margin: 10px 0 0 15px;
   width: 200px;
   height: auto;
   border-radius: 10px;
+  @media screen and (max-width: 420px) {
+    width: 50%;
+    margin: 10px 0 0 0px;
+  }
 `;
 
 export const ImageDeleteBtn = styled.button`
@@ -95,4 +101,10 @@ export const ImageDeleteBtn = styled.button`
   width: 2.2rem;
   height: 2.2rem;
   background: url(${ImageDelete}) no-repeat center / contain;
+  @media screen and (max-width: 420px) {
+    right: 17rem;
+  }
+  @media screen and (max-width: 375px) {
+    right: 14.8rem;
+  }
 `;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [] 신규 기능 추가 :
- [ ] 버그 수정 :
- [x] 리펙토링 : 게시물 업로드 이미지 반응형 적용
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 모바일 사이즈가 되었을 때 이미지 미리보기가 옆으로만 정렬이 되어 사용자 UX 불편함이 느껴져 리팩토링합니다

### 작업 내역

- 가로 사이즈가 420px이 되었을 때 이미지가 세로 정렬이 되고 이미지 사이즈가 작아집니다

### 작업 후 기대 동작(스크린샷)

![image](https://user-images.githubusercontent.com/102465469/182008739-f76a83af-54c5-4684-9481-9b6bacdba249.png)


### PR 특이 사항

- 특이 사항

### Issue Number 

close: #135 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
